### PR TITLE
bumping versions for laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,28 +1,28 @@
 {
-  "name": "unicodeveloper/laravel-feeder",
-  "description": "Laravel 5 Package to extract atom and rss feeds from any website",
-  "keywords": ["github", "laravel","Open Source","Evangelist", "Feeds", "Atom", "Rss", "laravel 5"],
-  "license": "MIT",
-  "authors": [
-      {
-        "name": "unicodeveloper",
-        "email": "prosperotemuyiwa@gmail.com"
-      }
-  ],
-  "minimum-stability": "stable",
-  "require": {
-    "php": ">=5.4.0",
-    "illuminate/support": "5.0.*"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "5.*"
-  },
-  "autoload": {
-        "psr-4": {
-          "Unicodeveloper\\LaravelFeeder\\": "src/"
+    "name": "unicodeveloper/laravel-feeder",
+    "description": "Laravel 5 Package to extract atom and rss feeds from any website",
+    "keywords": [ "github", "laravel", "Open Source", "Evangelist", "Feeds", "Atom", "Rss", "laravel 5" ],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "unicodeveloper",
+            "email": "prosperotemuyiwa@gmail.com"
         }
-   },
-   "autoload-dev": {
+    ],
+    "minimum-stability": "stable",
+    "require": {
+        "php": ">=7.0.0",
+        "illuminate/support": "^5.5"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~6.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Unicodeveloper\\LaravelFeeder\\": "src/"
+        }
+    },
+    "autoload-dev": {
         "psr-4": {
             "Unicodeveloper\\LaravelFeeder\\Test\\": "tests"
         }


### PR DESCRIPTION
This should fix the more recent Laravel framework version incompatibility problem.

I reformatted the composer file also to more closely match formatting of other composer.json files. 

Can I suggest adding tags to your library that match the version number of the framework?